### PR TITLE
Add inertial right click options

### DIFF
--- a/urdf_editor/include/urdf_editor/joint_property.h
+++ b/urdf_editor/include/urdf_editor/joint_property.h
@@ -16,7 +16,7 @@ namespace urdf_editor
     OriginProperty(urdf::Pose &origin);
     ~OriginProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -44,7 +44,7 @@ namespace urdf_editor
     JointAxisProperty(urdf::Vector3 &axis);
     ~JointAxisProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -72,7 +72,7 @@ namespace urdf_editor
     JointSafetyProperty(boost::shared_ptr<urdf::JointSafety> safety);
     ~JointSafetyProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -100,7 +100,7 @@ namespace urdf_editor
     JointMimicProperty(boost::shared_ptr<urdf::JointMimic> mimic, QStringList &joint_names);
     ~JointMimicProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -129,7 +129,7 @@ namespace urdf_editor
     JointCalibrationProperty(boost::shared_ptr<urdf::JointCalibration> calibration);
     ~JointCalibrationProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -157,7 +157,7 @@ namespace urdf_editor
     JointDynamicsProperty(boost::shared_ptr<urdf::JointDynamics> dynamics);
     ~JointDynamicsProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -185,7 +185,7 @@ namespace urdf_editor
     JointLimitsProperty(boost::shared_ptr<urdf::JointLimits> limits);
     ~JointLimitsProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 

--- a/urdf_editor/include/urdf_editor/link_property.h
+++ b/urdf_editor/include/urdf_editor/link_property.h
@@ -17,7 +17,7 @@ namespace urdf_editor
     LinkGeometryProperty(boost::shared_ptr<urdf::Geometry> geometry);
     ~LinkGeometryProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -44,7 +44,7 @@ namespace urdf_editor
     LinkCollisionProperty(boost::shared_ptr<urdf::Collision> collision);
     ~LinkCollisionProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -75,7 +75,7 @@ namespace urdf_editor
     LinkNewMaterialProperty(boost::shared_ptr<urdf::Material> material);
     ~LinkNewMaterialProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -103,7 +103,7 @@ namespace urdf_editor
     LinkVisualProperty(boost::shared_ptr<urdf::Visual> visual);
     ~LinkVisualProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
 
@@ -135,9 +135,13 @@ namespace urdf_editor
     LinkInertialProperty(boost::shared_ptr<urdf::Inertial> inertial);
     ~LinkInertialProperty();
 
-    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
+    void loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor);
 
     void loadData();
+
+    bool hasOriginProperty();
+
+    void createOriginProperty();
 
     QtProperty *getTopItem() { return top_item_; }
 
@@ -157,6 +161,7 @@ namespace urdf_editor
     boost::shared_ptr<OriginProperty> origin_property_;
 
   };
+  typedef boost::shared_ptr<LinkInertialProperty> LinkInertialPropertyPtr;
 
   class LinkProperty : public QObject
   {
@@ -168,6 +173,11 @@ namespace urdf_editor
     void loadProperty(boost::shared_ptr<QtTreePropertyBrowser> property_editor);
 
     void loadData();
+
+    bool hasInertialProperty();
+    void createInertialProperty();
+    LinkInertialPropertyPtr getInertialProperty();
+
 
   private slots:
     void onValueChanged(QtProperty *property, const QVariant &val);

--- a/urdf_editor/src/joint_property.cpp
+++ b/urdf_editor/src/joint_property.cpp
@@ -89,7 +89,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void OriginProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void OriginProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -174,7 +174,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void JointAxisProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void JointAxisProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -249,7 +249,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void JointSafetyProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void JointSafetyProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -324,7 +324,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void JointMimicProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void JointMimicProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -391,7 +391,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void JointCalibrationProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void JointCalibrationProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -456,7 +456,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void JointDynamicsProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void JointDynamicsProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -534,7 +534,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void JointLimitsProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void JointLimitsProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }

--- a/urdf_editor/src/link_property.cpp
+++ b/urdf_editor/src/link_property.cpp
@@ -126,7 +126,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void LinkGeometryProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void LinkGeometryProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -273,7 +273,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void LinkCollisionProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void LinkCollisionProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
     if (origin_property_)
@@ -354,7 +354,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void LinkNewMaterialProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void LinkNewMaterialProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
   }
@@ -468,7 +468,7 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void LinkVisualProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  void LinkVisualProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
     if (origin_property_)
@@ -591,7 +591,21 @@ namespace urdf_editor
     loading_ = false;
   }
 
-  void LinkInertialProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> property_editor)
+  bool LinkInertialProperty::hasOriginProperty()
+  {
+    return (origin_property_ != NULL);
+  }
+
+  void LinkInertialProperty::createOriginProperty()
+  {
+    if (!origin_property_)
+    {
+      origin_property_.reset(new OriginProperty(inertial_->origin));
+      top_item_->addSubProperty(origin_property_->getTopItem());
+    }
+  }
+
+  void LinkInertialProperty::loadFactoryForManager(boost::shared_ptr<QtTreePropertyBrowser> &property_editor)
   {
     property_editor->setFactoryForManager(manager_, factory_);
     if (origin_property_)
@@ -712,6 +726,25 @@ namespace urdf_editor
       collision_property_->loadFactoryForManager(property_editor);
       property_editor->addProperty(collision_property_->getTopItem());
     }
+  }
+
+  bool LinkProperty::hasInertialProperty()
+  {
+    return (inertial_property_ != NULL);
+  }
+
+  void LinkProperty::createInertialProperty()
+  {
+    if(!link_->inertial)
+    {
+      link_->inertial.reset(new urdf::Inertial());
+      inertial_property_.reset(new LinkInertialProperty(link_->inertial));
+    }
+  }
+
+  LinkInertialPropertyPtr LinkProperty::getInertialProperty()
+  {
+    return inertial_property_;
   }
 
   void LinkProperty::onValueChanged(QtProperty *property, const QVariant &val)


### PR DESCRIPTION
This commit adds the inertial right click options. It is also to provide a guide to other developers on how to implement the remaining right click options for the property window. This is a start to addressing issue #9.
