### PR TITLE
Fix for issue #17: fading grid when using billboards

### DIFF
--- a/urdf_editor/src/my_rviz.cpp
+++ b/urdf_editor/src/my_rviz.cpp
@@ -26,7 +26,6 @@ namespace urdf_editor
     manager_->addDisplay(robot_display_, false);
 
     grid_display_ = manager_->createDisplay("rviz/Grid", "MyGrid", true);
-    grid_display_->subProp("Line Style")->setValue("Billboards");
   }
 
   // Destructor


### PR DESCRIPTION
This change configures the Grid to use the default `lines` style for now.

If/when ros-visualization/rviz#987 gets fixed we could revert this and start using `Billboards` again.
