### PR TITLE
Fix for issue #108: update Travis config to first install the OCE development libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ env:
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:
+  - source .travis_ppa_oce.sh
   - source .ci_config/travis.sh

--- a/.travis_ppa_oce.sh
+++ b/.travis_ppa_oce.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+sudo add-apt-repository -y ppa:freecad-maintainers/freecad-stable
+sudo apt-get update
+sudo apt-get install -y -qq \
+  liboce-foundation-dev \
+  liboce-modeling-dev \
+  liboce-ocaf-dev \
+  liboce-ocaf-lite-dev \
+  liboce-visualization-dev


### PR DESCRIPTION
Minor change to the Travis config which makes it first install the `liboce-*` libraries needed since we merged #102.

Without this change, all builds will fail as `liboce` is not part of a standard Trusty install.
